### PR TITLE
Add bump_cache_version helper

### DIFF
--- a/tennis/storage.py
+++ b/tennis/storage.py
@@ -63,6 +63,18 @@ def increment_cache_version() -> int:
         return 0
 
 
+def bump_cache_version() -> int:
+    """Increment and return the cache version stored in Redis."""
+    return increment_cache_version()
+
+
+__all__ = [
+    "get_cache_version",
+    "increment_cache_version",
+    "bump_cache_version",
+]
+
+
 class _PgCursor:
     def __init__(self, cursor):
         self._c = cursor


### PR DESCRIPTION
## Summary
- alias increment_cache_version via new bump_cache_version
- export cache version helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6860e3a544d4832f8b7c785536e5d240