### PR TITLE
docs: explain redis caching

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -36,7 +36,20 @@ The default SQLite database contains these tables: `users`, `players`, `clubs`,
 To enable caching export a `REDIS_URL` pointing to a running Redis server. For
 example install Redis locally and set `export REDIS_URL=redis://localhost:6379/0`.
 
-## 3. Start the API server
+## 3. Deploy Redis
+
+Install and start a Redis server. Set the `REDIS_URL` environment variable so
+the application can connect, for example:
+
+```bash
+export REDIS_URL=redis://localhost:6379/0
+```
+
+When running the API with multiple worker processes the server stores a
+`CACHE_VERSION` key in Redis. Each worker checks this value and reloads cached
+data whenever it changes to keep state consistent.
+
+## 4. Start the API server
 
 Launch the FastAPI application. A local `tennis.db` SQLite database will be created automatically if it does not exist. Set `DATABASE_URL` to a PostgreSQL DSN if you prefer using a server.
 
@@ -50,7 +63,7 @@ All runtime data is persisted in SQLite or PostgreSQL depending on
 `DATABASE_URL`. Because the API accesses the database for every request you can
 run multiple stateless instances behind a load balancer.
 
-## 4. Import the mini program
+## 5. Import the mini program
 
 1. Open WeChat Developer Tools and choose **Import**.
 2. Select the `miniapp` directory from this repository.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ If the `REDIS_URL` environment variable is set the application caches loaded
 club and user data in Redis for faster access. A running Redis server is
 required for this feature, for example `export REDIS_URL=redis://localhost:6379/0`.
 Cached entries expire automatically after a few minutes.
+Every write operation bumps a `CACHE_VERSION` value in Redis so that multiple
+API workers reload their local cache when the version changes.
 
 ### Environment configuration
 
@@ -54,6 +56,11 @@ WECHAT_SECRET=your-secret
 
 Install `python-dotenv` with `pip install python-dotenv` if you want to use a
 `.env` file during development.
+
+When caching is enabled via `REDIS_URL` the server stores a `CACHE_VERSION`
+value in Redis. All workers compare this version on each request and reload
+their cached data whenever it changes. Ensure all processes point to the same
+Redis instance.
 
 Available format names:
 


### PR DESCRIPTION
## Summary
- document the Redis cache version mechanism in README
- add Redis deployment step in DEPLOYMENT.md explaining shared CACHE_VERSION

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6860ec70bae8832f93b743db29c78cb1