### PR TITLE
Add avatar upload integration tests

### DIFF
--- a/miniapp/test/upload.test.js
+++ b/miniapp/test/upload.test.js
@@ -1,0 +1,48 @@
+const simulate = require('miniprogram-simulate');
+const path = require('path');
+const store = require('../store/store');
+
+test('avatar upload and submit', async () => {
+  global.getApp = () => ({ globalData: { BASE_URL: 'http://server' } });
+  store.token = 'TOKEN';
+  store.userId = 'u1';
+
+  global.wx = {
+    uploadFile: jest.fn(opts => {
+      opts.success({ statusCode: 200, data: JSON.stringify({ url: 'http://server/uploads/a.png' }) });
+    }),
+    request: jest.fn(opts => {
+      opts.success({ statusCode: 200, data: {} });
+    }),
+    showLoading: jest.fn(),
+    hideLoading: jest.fn(),
+    showToast: jest.fn(),
+    navigateBack: jest.fn(),
+    setStorageSync: jest.fn(),
+    removeStorageSync: jest.fn()
+  };
+
+  const id = simulate.load(path.join(__dirname, '../pages/editprofile/editprofile'), 'page');
+  const comp = simulate.render(id);
+  comp.attach(document.createElement('parent-wrapper'));
+
+  comp.setData({
+    userId: 'u1',
+    name: 'U1',
+    genderIndex: 1,
+    birth: '1990-01-01',
+    handIndex: 1,
+    backhandIndex: 1,
+    region: ['A', 'B', 'C'],
+    regionString: 'A B C',
+    avatar: 'wxfile://tmp.png',
+    tempAvatar: 'wxfile://tmp.png'
+  });
+
+  await comp.instance.submit();
+
+  expect(wx.uploadFile).toHaveBeenCalled();
+  const putCall = wx.request.mock.calls.find(c => c[0].method === 'PUT');
+  expect(putCall).toBeTruthy();
+  expect(wx.navigateBack).toHaveBeenCalled();
+});

--- a/tests/test_upload_update.py
+++ b/tests/test_upload_update.py
@@ -1,0 +1,38 @@
+import importlib
+from fastapi.testclient import TestClient
+import tennis.storage as storage
+import tennis.services.state as state
+
+
+def test_upload_then_update_avatar(tmp_path, monkeypatch):
+    db = tmp_path / "tennis.db"
+    monkeypatch.setattr(storage, "DB_FILE", db)
+    importlib.reload(state)
+    api = importlib.reload(importlib.import_module("tennis.api"))
+    client = TestClient(api.app)
+
+    client.post(
+        "/users",
+        json={"user_id": "u1", "name": "U1", "password": "pw"},
+    )
+    token = client.post("/login", json={"user_id": "u1", "password": "pw"}).json()["token"]
+
+    img = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+        b"\x00\x00\x00\nIDATx\xda\x63\xf8\x0f\x00\x01\x01\x01\x00\x18\xdd\x8d\xa5\x00\x00\x00\x00IEND\xaeB\x60\x82"
+    )
+    resp = client.post("/upload", files={"file": ("a.png", img, "image/png")})
+    assert resp.status_code == 200
+    url = resp.json()["url"]
+
+    resp = client.put(
+        "/players/u1",
+        json={"user_id": "u1", "token": token, "avatar": url},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+    with storage._connect() as conn:
+        row = conn.execute("SELECT avatar FROM players WHERE user_id = 'u1'").fetchone()
+        assert row is not None
+        assert row[0] == url


### PR DESCRIPTION
## Summary
- test avatar upload through API and update player avatar URL
- simulate avatar upload flow in miniapp using miniprogram-simulate

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: testing.postgresql)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861392217e4832fafd1b68c1404a30a