### PR TITLE
Fix admin rating input and card style

### DIFF
--- a/miniapp/pkg_manage/sys-user-detail/index.wxml
+++ b/miniapp/pkg_manage/sys-user-detail/index.wxml
@@ -31,11 +31,11 @@
       <view class="dialog-title">调整评分</view>
       <view class="edit-row">
         <text>单打评分</text>
-        <input type="number" value="{{ratingSingles}}" bindinput="onSinglesInput" />
+        <input type="digit" value="{{ratingSingles}}" bindinput="onSinglesInput" />
       </view>
       <view class="edit-row">
         <text>双打评分</text>
-        <input type="number" value="{{ratingDoubles}}" bindinput="onDoublesInput" />
+        <input type="digit" value="{{ratingDoubles}}" bindinput="onDoublesInput" />
       </view>
       <button class="primary-btn" bindtap="saveRating">保存</button>
     </view>

--- a/miniapp/pkg_manage/sys-user-detail/index.wxss
+++ b/miniapp/pkg_manage/sys-user-detail/index.wxss
@@ -1,4 +1,4 @@
-.page-container{padding:20rpx;background:#f5f5f5;min-height:100vh;}
+.page-container{padding:12rpx;background:#f5f5f5;min-height:100vh;}
 .section-title{margin:20rpx 0 10rpx 0;font-size:30rpx;font-weight:bold;}
 .club-list{}
 .club-card{width:100%;background:#fff;border-radius:16rpx;margin-bottom:20rpx;padding:24rpx;box-shadow:0 4rpx 12rpx rgba(0,0,0,0.05);display:flex;justify-content:space-between;box-sizing:border-box;}


### PR DESCRIPTION
## Summary
- unify layout of admin user record list by matching padding with normal record pages
- allow decimal keyboard for admin rating inputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_68651ebf76bc832f986204cc46f2ac91