### PR TITLE
Fix avatar field name mismatch in profile update

### DIFF
--- a/miniapp/pages/editprofile/editprofile.js
+++ b/miniapp/pages/editprofile/editprofile.js
@@ -138,12 +138,12 @@ Page({
         handedness: this.data.handOptions[this.data.handIndex] || '',
         backhand: this.data.backhandOptions[this.data.backhandIndex] || '',
         region: this.data.regionString,
-        avatar: this.data.avatar
+        avatar_url: this.data.avatar
       };
 
       if (this.data.newAvatarTempPath) {
         const permanentRelativeUrl = await uploadAvatar(this.data.newAvatarTempPath);
-        finalPayload.avatar = permanentRelativeUrl;
+        finalPayload.avatar_url = permanentRelativeUrl;
       }
 
       // ======================= 新增的诊断代码在这里 =======================


### PR DESCRIPTION
## Summary
- update profile submission payload to use `avatar_url`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68652788552c832faeddac78d0b63019