### PR TITLE
Fix avatar upload auth and path handling

### DIFF
--- a/miniapp/pages/editprofile/editprofile.js
+++ b/miniapp/pages/editprofile/editprofile.js
@@ -11,9 +11,8 @@ const {
 const uploadAvatar = require('../../utils/upload');
 const userService = require('../../services/user');
 
-function ensureSlash(p) {
-  return p.startsWith('/') ? p : '/' + p;
-}
+// 保证以 / 开头，方便 withBase() 拼接
+const ensureSlash = p => p.startsWith('/') ? p : '/' + p;
 
 Page({
   data: {
@@ -142,7 +141,7 @@ Page({
         handedness: this.data.handOptions[this.data.handIndex] || '',
         backhand: this.data.backhandOptions[this.data.backhandIndex] || '',
         region: this.data.regionString,
-        avatar: this.data.avatar
+        avatar: ensureSlash(this.data.avatar || '')
       };
 
       if (this.data.newAvatarTempPath) {

--- a/miniapp/utils/upload.js
+++ b/miniapp/utils/upload.js
@@ -1,4 +1,5 @@
 // miniapp/utils/upload.js
+const store = require('../store/store');
 
 /**
  * 封装 wx.uploadFile, 用于上传文件并返回服务器提供的URL
@@ -8,7 +9,7 @@
 function uploadAvatar(filePath) {
   // 在函数调用时才获取 BASE_URL，确保其已就绪
   const BASE_URL = getApp().globalData.BASE_URL;
-  const token = wx.getStorageSync('authToken');
+  const token = store.token || wx.getStorageSync('token');
 
   // 返回一个 Promise，便于使用 async/await
   return new Promise((resolve, reject) => {
@@ -18,9 +19,7 @@ function uploadAvatar(filePath) {
       url: `${BASE_URL}/upload/image`,
       filePath,
       name: 'file',
-      header: {
-        'Authorization': `Bearer ${token}`,
-      },
+      header: token ? { 'Authorization': `Bearer ${token}` } : {},
       success(res) {
         try {
           if (typeof res.data !== 'string') {


### PR DESCRIPTION
## Summary
- ensure `upload.js` reads auth token from mobx store or storage
- sanitize avatar paths in edit profile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_686541e0b958832f95edeb3e00a89da4