### PR TITLE
Fix admin record cards

### DIFF
--- a/miniapp/components/record-card/record-card.wxss
+++ b/miniapp/components/record-card/record-card.wxss
@@ -11,11 +11,11 @@
 .info.doubles{justify-content:flex-start; margin-left:120rpx;} /* Added margin-left */
 .unit{display:flex;align-items:center;margin-right:10rpx;flex:1 0 auto;width:50%;}
 .unit:last-child{margin-right:0;}
-.avatar{width:48rpx;height:48rpx;border-radius:50%;margin-right:12rpx;background:#ccc;flex-shrink:0;}
-.name{color:#333;font-size:26rpx;max-width:120rpx;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
-.score{width:100rpx;margin-right:20rpx;margin-left:35rpx;text-align:center;font-size:48rpx;font-weight:700;color:#000;}
-.rating{margin-left:8rpx;font-size:26rpx;color:#333;}
-.delta{font-size:22rpx;margin-left:8rpx;}
+.record-card .avatar{width:48rpx;height:48rpx;border-radius:50%;margin-right:12rpx;background:#ccc;flex-shrink:0;}
+.record-card .name{color:#333;font-size:26rpx;max-width:120rpx;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.record-card .score{width:100rpx;margin-right:20rpx;margin-left:35rpx;text-align:center;font-size:48rpx;font-weight:700;color:#000;}
+.record-card .rating{margin-left:8rpx;font-size:26rpx;color:#333;}
+.record-card .delta{font-size:22rpx;margin-left:8rpx;}
 .pos{color:#2f8f2f;}
 .neg{color:#e03a3a;}
 .neutral{color:gray;}

--- a/miniapp/pkg_manage/sys-match-list/index.js
+++ b/miniapp/pkg_manage/sys-match-list/index.js
@@ -77,12 +77,30 @@ Page({
             rec.partnerRating = rec.rating_a2_after != null ? Number(rec.rating_a2_after).toFixed(3) : '';
             rec.opp1Rating = rec.rating_b1_after != null ? Number(rec.rating_b1_after).toFixed(3) : '';
             rec.opp2Rating = rec.rating_b2_after != null ? Number(rec.rating_b2_after).toFixed(3) : '';
-            // deltas
-            const pd = rec.rating_a1_after != null && rec.rating_a1_before != null ? rec.rating_a1_after - rec.rating_a1_before : null;
-            if (pd != null) {
-              const abs = Math.abs(pd).toFixed(3);
-              rec.deltaDisplayA = (pd > 0 ? '+' : pd < 0 ? '-' : '') + abs;
-              rec.deltaClassA = pd > 0 ? 'pos' : pd < 0 ? 'neg' : 'neutral';
+            // deltas for all participants
+            const dA1 = rec.rating_a1_after != null && rec.rating_a1_before != null ? rec.rating_a1_after - rec.rating_a1_before : null;
+            if (dA1 != null) {
+              const abs = Math.abs(dA1).toFixed(3);
+              rec.deltaDisplayA = (dA1 > 0 ? '+' : dA1 < 0 ? '-' : '') + abs;
+              rec.deltaClassA = dA1 > 0 ? 'pos' : dA1 < 0 ? 'neg' : 'neutral';
+            }
+            const dA2 = rec.rating_a2_after != null && rec.rating_a2_before != null ? rec.rating_a2_after - rec.rating_a2_before : null;
+            if (dA2 != null) {
+              const abs = Math.abs(dA2).toFixed(3);
+              rec.partnerDeltaDisplay = (dA2 > 0 ? '+' : dA2 < 0 ? '-' : '') + abs;
+              rec.partnerDeltaClass = dA2 > 0 ? 'pos' : dA2 < 0 ? 'neg' : 'neutral';
+            }
+            const dB1 = rec.rating_b1_after != null && rec.rating_b1_before != null ? rec.rating_b1_after - rec.rating_b1_before : null;
+            if (dB1 != null) {
+              const abs = Math.abs(dB1).toFixed(3);
+              rec.opp1DeltaDisplay = (dB1 > 0 ? '+' : dB1 < 0 ? '-' : '') + abs;
+              rec.opp1DeltaClass = dB1 > 0 ? 'pos' : dB1 < 0 ? 'neg' : 'neutral';
+            }
+            const dB2 = rec.rating_b2_after != null && rec.rating_b2_before != null ? rec.rating_b2_after - rec.rating_b2_before : null;
+            if (dB2 != null) {
+              const abs = Math.abs(dB2).toFixed(3);
+              rec.opp2DeltaDisplay = (dB2 > 0 ? '+' : dB2 < 0 ? '-' : '') + abs;
+              rec.opp2DeltaClass = dB2 > 0 ? 'pos' : dB2 < 0 ? 'neg' : 'neutral';
             }
           }
           rec.displayFormat = displayFormat(rec.format);

--- a/miniapp/pkg_manage/sys-user-detail/index.js
+++ b/miniapp/pkg_manage/sys-user-detail/index.js
@@ -193,12 +193,35 @@ Page({
             rec.partnerName = rec.partner || '';
             rec.partnerAvatar = withBase(rec.partner_avatar) || placeholder;
             rec.partnerRating = rec.partner_rating_after != null ? Number(rec.partner_rating_after).toFixed(3) : '';
+            const pd = rec.partner_delta;
+            if (pd != null) {
+              const deltaP = Number(pd);
+              const abs = Math.abs(deltaP).toFixed(3);
+              rec.partnerDeltaDisplay = (deltaP > 0 ? '+' : deltaP < 0 ? '-' : '') + abs;
+              rec.partnerDeltaClass = deltaP > 0 ? 'pos' : deltaP < 0 ? 'neg' : 'neutral';
+            }
+
             rec.opp1Name = rec.opponent1 || '';
             rec.opp1Avatar = withBase(rec.opponent1_avatar) || placeholder;
             rec.opp1Rating = rec.opponent1_rating_after != null ? Number(rec.opponent1_rating_after).toFixed(3) : '';
+            const od1 = rec.opponent1_delta;
+            if (od1 != null) {
+              const delta1 = Number(od1);
+              const abs = Math.abs(delta1).toFixed(3);
+              rec.opp1DeltaDisplay = (delta1 > 0 ? '+' : delta1 < 0 ? '-' : '') + abs;
+              rec.opp1DeltaClass = delta1 > 0 ? 'pos' : delta1 < 0 ? 'neg' : 'neutral';
+            }
+
             rec.opp2Name = rec.opponent2 || '';
             rec.opp2Avatar = withBase(rec.opponent2_avatar) || placeholder;
             rec.opp2Rating = rec.opponent2_rating_after != null ? Number(rec.opponent2_rating_after).toFixed(3) : '';
+            const od2 = rec.opponent2_delta;
+            if (od2 != null) {
+              const delta2 = Number(od2);
+              const abs = Math.abs(delta2).toFixed(3);
+              rec.opp2DeltaDisplay = (delta2 > 0 ? '+' : delta2 < 0 ? '-' : '') + abs;
+              rec.opp2DeltaClass = delta2 > 0 ? 'pos' : delta2 < 0 ? 'neg' : 'neutral';
+            }
           }
           rec.displayFormat = displayFormat(rec.format);
         });


### PR DESCRIPTION
## Summary
- ensure avatar styles in record cards can't be overwritten
- show all participant rating deltas in system match list
- show all participant rating deltas in system user detail

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6867c3ab9d5c832fbc18d9cf5a9c45a3