### PR TITLE
Add subscribe API and client integration

### DIFF
--- a/miniapp/utils/ensureSubscribe.js
+++ b/miniapp/utils/ensureSubscribe.js
@@ -1,10 +1,19 @@
 const TEMPLATE_ID = 'uqaaIKXK918Yz4FGODyiuB4uJgMFkXC_63vTGq-0G2c';
+const BASE_URL = getApp().globalData.BASE_URL;
+const store = require('../store/store');
+const request = require('./request');
 
 function ensureSubscribe(scene) {
   return new Promise(resolve => {
     wx.requestSubscribeMessage({
       tmplIds: [TEMPLATE_ID],
-      success() { resolve(); },
+      success() {
+        request({
+          url: `${BASE_URL}/subscribe`,
+          method: 'POST',
+          data: { user_id: store.userId, token: store.token, scene }
+        }).finally(() => resolve());
+      },
       fail() { wx.showToast({ title: '请授权接收通知', icon: 'none' }); resolve(); }
     });
   });

--- a/tennis/routes/users.py
+++ b/tennis/routes/users.py
@@ -4,7 +4,7 @@ from ..services import users as user_service
 from ..services.auth import require_auth, assert_token_matches
 from ..services.helpers import get_user_or_404
 
-from ..storage import get_user, get_player
+from ..storage import get_user, get_player, add_subscribe_quota
 from .. import api
 
 router = APIRouter()
@@ -42,6 +42,12 @@ class RefreshRequest(BaseModel):
 
 class WeChatLoginRequest(BaseModel):
     code: str
+
+
+class SubscribeRequest(BaseModel):
+    user_id: str
+    scene: str
+    token: str
 
 
 @router.post("/users")
@@ -131,4 +137,12 @@ def mark_message_read(user_id: str, index: int, authorization: str | None = Head
     assert_token_matches(uid, user_id)
     user = get_user_or_404(user_id)
     user_service.mark_read(user, index)
+    return {"status": "ok"}
+
+
+@router.post("/subscribe")
+def subscribe(data: SubscribeRequest, authorization: str | None = Header(None)):
+    uid = require_auth(authorization)
+    assert_token_matches(uid, data.user_id)
+    add_subscribe_quota(data.user_id, data.scene)
     return {"status": "ok"}

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -1,0 +1,42 @@
+import importlib
+from fastapi.testclient import TestClient
+import tennis.storage as storage
+import tennis.services.state as state
+
+
+def test_subscribe_quota_and_log(tmp_path, monkeypatch):
+    db = tmp_path / "tennis.db"
+    monkeypatch.setattr(storage, "DB_FILE", db)
+    importlib.reload(state)
+    api = importlib.reload(importlib.import_module("tennis.api"))
+    wechat = importlib.reload(importlib.import_module("tennis.wechat"))
+
+    client = TestClient(api.app)
+
+    client.post("/users", json={"user_id": "u1", "name": "U1", "password": "pw", "allow_create": True})
+    token = client.post("/login", json={"user_id": "u1", "password": "pw"}).json()["token"]
+
+    resp = client.post("/subscribe", json={"user_id": "u1", "scene": "audit", "token": token})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+    with storage._connect() as conn:
+        row = conn.execute(
+            "SELECT quota FROM user_subscribe WHERE user_id = ? AND scene = ?",
+            ("u1", "audit"),
+        ).fetchone()
+        assert row is not None and row[0] == 1
+
+    async def fake_send(openid, audit_type, audit_status, page):
+        return {"errcode": 43101, "errmsg": "fail"}
+
+    monkeypatch.setattr(wechat, "_send", fake_send)
+
+    wechat.send_audit_message("u1", "wx", "audit", "type", "status", "p")
+
+    with storage._connect() as conn:
+        row = conn.execute(
+            "SELECT errcode FROM subscribe_log WHERE user_id = ? AND scene = ?",
+            ("u1", "audit"),
+        ).fetchone()
+        assert row is not None and row[0] == 43101


### PR DESCRIPTION
## Summary
- add `/subscribe` endpoint to manage miniapp message quotas
- call new endpoint from `ensureSubscribe.js`
- test subscription quota increment and log recording

## Testing
- `pytest -q tests/test_subscribe.py` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6868a430c29c832fabcd89c48e833e59