### PR TITLE
Add subscription checks on profile login

### DIFF
--- a/miniapp/pages/profile/profile.js
+++ b/miniapp/pages/profile/profile.js
@@ -4,6 +4,7 @@ const userService = require('../../services/user');
 const store = require('../../store/store');
 const { hideKeyboard } = require('../../utils/hideKeyboard');
 const { t } = require('../../utils/locales');
+const ensureSubscribe = require('../../utils/ensureSubscribe');
 
 Page({
   data: {
@@ -32,6 +33,8 @@ Page({
     const uid = store.userId;
     const cid = store.clubId;
     if (uid) {
+      ensureSubscribe('club_join');
+      ensureSubscribe('match');
       this.setData({ loggedIn: true });
       this.loadJoinedClubs(uid, cid);
     } else {
@@ -91,6 +94,8 @@ Page({
             .then(resp => {
               if (resp.access_token) {
                 store.setAuth(resp.access_token, resp.user_id, resp.refresh_token);
+                ensureSubscribe('club_join');
+                ensureSubscribe('match');
                 this.setData({ loggedIn: true });
                 if (resp.just_created) {
                   wx.navigateTo({ url: '/pages/editprofile/editprofile' });


### PR DESCRIPTION
## Summary
- require `ensureSubscribe` in profile page
- subscribe to notifications when user is already logged in on page show
- subscribe to notifications right after successful login

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6868e5b6f6a4832f9abdd630aa833428