### PR TITLE
Fix sys admin approval of pending matches

### DIFF
--- a/miniapp/pkg_manage/sys-pending/index.js
+++ b/miniapp/pkg_manage/sys-pending/index.js
@@ -89,7 +89,7 @@ Page({
     }
   },
   approveSingle(e) {
-    const idx = e.currentTarget.dataset.index || e.detail.index;
+    const idx = e.currentTarget.dataset.id || e.detail.id;
     const cid = e.currentTarget.dataset.club;
     const that = this;
     request({
@@ -101,12 +101,12 @@ Page({
     });
   },
   vetoSingle(e) {
-    const idx = e.currentTarget.dataset.index || e.detail.index;
+    const idx = e.currentTarget.dataset.id || e.detail.id;
     const cid = e.currentTarget.dataset.club;
     const that = this;
     // Optimistically remove the item so the UI updates immediately
     const arr = this.data.singles.slice();
-    const pos = arr.findIndex(it => it.index === idx);
+    const pos = arr.findIndex(it => it.id === idx);
     if (pos !== -1) {
       arr.splice(pos, 1);
       this.setData({ singles: arr });
@@ -119,7 +119,7 @@ Page({
     });
   },
   approveDouble(e) {
-    const idx = e.currentTarget.dataset.index || e.detail.index;
+    const idx = e.currentTarget.dataset.id || e.detail.id;
     const cid = e.currentTarget.dataset.club;
     const that = this;
     request({
@@ -131,12 +131,12 @@ Page({
     });
   },
   vetoDouble(e) {
-    const idx = e.currentTarget.dataset.index || e.detail.index;
+    const idx = e.currentTarget.dataset.id || e.detail.id;
     const cid = e.currentTarget.dataset.club;
     const that = this;
     // Optimistically remove the item so the UI updates immediately
     const arr = this.data.doublesList.slice();
-    const pos = arr.findIndex(it => it.index === idx);
+    const pos = arr.findIndex(it => it.id === idx);
     if (pos !== -1) {
       arr.splice(pos, 1);
       this.setData({ doublesList: arr });

--- a/miniapp/pkg_manage/sys-pending/index.wxml
+++ b/miniapp/pkg_manage/sys-pending/index.wxml
@@ -5,13 +5,13 @@
   </view>
   <block wx:if="{{modeIndex==0}}">
     <block wx:for="{{singles}}" wx:key="index">
-      <record-card record="{{item}}" doubles="{{false}}" show-actions="{{true}}" data-index="{{item.index}}" data-club="{{item.club_id}}" status-text="{{item.statusText}}" can-approve="{{item.canApprove}}" can-veto="{{item.canVeto}}" can-share="{{item.canShare}}" bind:approve="approveSingle" bind:veto="vetoSingle" />
+      <record-card record="{{item}}" doubles="{{false}}" show-actions="{{true}}" data-id="{{item.id}}" data-club="{{item.club_id}}" status-text="{{item.statusText}}" can-approve="{{item.canApprove}}" can-veto="{{item.canVeto}}" can-share="{{item.canShare}}" bind:approve="approveSingle" bind:veto="vetoSingle" />
     </block>
     <view wx:if="{{!singles.length}}" class="empty">暂无数据</view>
   </block>
   <block wx:elif="{{modeIndex==1}}">
     <block wx:for="{{doublesList}}" wx:key="index">
-        <record-card record="{{item}}" doubles="{{true}}" show-actions="{{true}}" data-index="{{item.index}}" data-club="{{item.club_id}}" status-text="{{item.statusText}}" can-approve="{{item.canApprove}}" can-veto="{{item.canVeto}}" can-share="{{item.canShare}}" bind:approve="approveDouble" bind:veto="vetoDouble" />
+        <record-card record="{{item}}" doubles="{{true}}" show-actions="{{true}}" data-id="{{item.id}}" data-club="{{item.club_id}}" status-text="{{item.statusText}}" can-approve="{{item.canApprove}}" can-veto="{{item.canVeto}}" can-share="{{item.canShare}}" bind:approve="approveDouble" bind:veto="vetoDouble" />
     </block>
     <view wx:if="{{!doublesList.length}}" class="empty">暂无数据</view>
   </block>

--- a/tennis/api.py
+++ b/tennis/api.py
@@ -1646,6 +1646,7 @@ def list_all_pending_matches(authorization: str | None = Header(None)) -> list[d
             entry = {
                 "club_id": cid,
                 "index": idx,
+                "id": m.id,
                 "date": m.date.isoformat(),
                 "player_a": m.player_a.user_id,
                 "player_b": m.player_b.user_id,
@@ -1712,6 +1713,7 @@ def list_all_pending_doubles(authorization: str | None = Header(None)) -> list[d
             entry = {
                 "club_id": cid,
                 "index": idx,
+                "id": m.id,
                 "date": m.date.isoformat(),
                 "a1": m.player_a1.user_id,
                 "a2": m.player_a2.user_id,


### PR DESCRIPTION
## Summary
- add match ID to `list_all_pending_matches` and `list_all_pending_doubles`
- use match id in system pending miniapp page for approval/veto actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6868ee5c8f34832fad7fc7529093aad3