### PR TITLE
Await subscriptions before navigation

### DIFF
--- a/miniapp/pages/login/index.js
+++ b/miniapp/pages/login/index.js
@@ -7,24 +7,23 @@ const ensureSubscribe = require('../../utils/ensureSubscribe');
 Page({
   data: { t },
   hideKeyboard,
-  wechatLogin() {
-    wx.login({
-      success(res) {
-        if (!res.code) return;
-        userService
-          .wechatLogin(res.code)
-          .then(resp => {
-            if (resp.access_token) {
-              store.setAuth(resp.access_token, resp.user_id, resp.refresh_token);
-              ensureSubscribe('club_join');
-              ensureSubscribe('match');
-              wx.navigateBack();
-            } else {
-              wx.showToast({ duration: 4000,  title: t.loginFailed, icon: 'none' });
-            }
-          })
-          .catch(() => {});
+  async wechatLogin() {
+    try {
+      const res = await new Promise((resolve, reject) => {
+        wx.login({ success: resolve, fail: reject });
+      });
+      if (!res.code) return;
+      const resp = await userService.wechatLogin(res.code);
+      if (resp.access_token) {
+        store.setAuth(resp.access_token, resp.user_id, resp.refresh_token);
+        await ensureSubscribe('club_join');
+        await ensureSubscribe('match');
+        wx.navigateBack();
+      } else {
+        wx.showToast({ duration: 4000, title: t.loginFailed, icon: 'none' });
       }
-    });
+    } catch (e) {
+      // ignore
+    }
   }
 });


### PR DESCRIPTION
## Summary
- convert login flows to async/await
- ensure subscription prompts resolve before navigating

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6869e45aca4c832fa22ddd393e55e4f6