### PR TITLE
Update subscription handling for club pages

### DIFF
--- a/miniapp/pages/manage/manage.js
+++ b/miniapp/pages/manage/manage.js
@@ -5,7 +5,6 @@ const { zh_CN } = require('../../utils/locales.js');
 const { genderText } = require('../../utils/userFormat');
 const store = require('../../store/store');
 const { withBase } = require('../../utils/format');
-const ensureSubscribe = require('../../utils/ensureSubscribe');
 
 Page({
   data: {
@@ -35,8 +34,6 @@ Page({
     this.checkSysAdmin();
   },
   onShow() {
-    ensureSubscribe('club_join');
-    ensureSubscribe('match');
     this.fetchPlayers();
   },
   checkSysAdmin() {

--- a/miniapp/pages/profile/profile.js
+++ b/miniapp/pages/profile/profile.js
@@ -33,8 +33,6 @@ Page({
     const uid = store.userId;
     const cid = store.clubId;
     if (uid) {
-      ensureSubscribe('club_join');
-      ensureSubscribe('match');
       this.setData({ loggedIn: true });
       this.loadJoinedClubs(uid, cid);
     } else {
@@ -115,8 +113,10 @@ Page({
       wx.navigateTo({ url: '/pages/playercard/playercard' });
     }
   },
-  goMyClub() {
+  async goMyClub() {
     if (!this.data.loggedIn) return;
+    await ensureSubscribe('club_join');
+    await ensureSubscribe('match');
     wx.navigateTo({ url: '/pkg_club/club-manage/index' });
   },
   goMyNotes() {

--- a/miniapp/pkg_club/club-manage/index.js
+++ b/miniapp/pkg_club/club-manage/index.js
@@ -4,6 +4,7 @@ const { hideKeyboard } = require('../../utils/hideKeyboard');
 const { zh_CN } = require('../../utils/locales.js');
 const { formatClubCardData } = require('../../utils/clubFormat');
 const store = require('../../store/store');
+const ensureSubscribe = require('../../utils/ensureSubscribe');
 
 Page({
   data: {
@@ -65,9 +66,11 @@ Page({
       }
     });
   },
-  openClub(e) {
+  async openClub(e) {
     const cid = e.detail.club ? e.detail.club.club_id : '';
     if (cid) {
+      await ensureSubscribe('club_join');
+      await ensureSubscribe('match');
       store.setClubId(cid);
       wx.navigateTo({ url: `/pages/manage/manage?cid=${cid}` });
     }


### PR DESCRIPTION
## Summary
- remove redundant `ensureSubscribe` calls from profile and manage page lifecycle hooks
- request subscription before opening the user club management page
- request subscription before navigating to club management from the club list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6869e54c59ec832fbdd1e074aa6c2f8f