### PR TITLE
Fix subscription toast and ask on new match

### DIFF
--- a/miniapp/pages/records/records.js
+++ b/miniapp/pages/records/records.js
@@ -428,7 +428,8 @@ Page({
         encodeURIComponent(JSON.stringify(rec))
     });
   },
-  addMatch() {
+  async addMatch() {
+    await ensureSubscribe('match');
     wx.navigateTo({ url: '/pages/addmatch/addmatch' });
   },
   onPullDownRefresh() {

--- a/miniapp/utils/ensureSubscribe.js
+++ b/miniapp/utils/ensureSubscribe.js
@@ -14,7 +14,7 @@ function ensureSubscribe(scene) {
           data: { user_id: store.userId, token: store.token, scene }
         }).finally(() => resolve());
       },
-      fail() { wx.showToast({ title: '请授权接收通知', icon: 'none' }); resolve(); }
+      fail() { resolve(); }
     });
   });
 }


### PR DESCRIPTION
## Summary
- prevent showing a toast when subscription fails
- ask for match notifications before navigating to match creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869da9d76c4832f8e71cef420542e04