### PR TITLE
Refactor subscription scenes

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,24 @@ npm run lint
 
 Basic front‑end tests using `miniprogram-simulate` can be executed with `npm test`.
 
+### WeChat subscription messages
+
+The mini program requests message push authorization only when needed. The
+backend tracks quota usage per **scene** identifier:
+
+- `club_manage` – leaders and admins receive notifications about pending join
+  requests. Permission is requested when an admin approves or rejects an
+  application.
+- `join_club` – applicants are informed when their join request is approved or
+  rejected. Authorization happens when submitting the request.
+- `match_confirm` – opponents are notified of a newly created match. The
+  subscription is requested when opening the pending match list.
+- `match_audit` – club staff are asked to review confirmed matches. Permission is
+  requested when they tap the approve or veto buttons.
+- `match_create` – players are informed when a match is rejected or approved.
+  Authorization occurs after submitting a match or confirming an opponent's
+  match.
+
 ### Testing
 
 To run the test suite:

--- a/miniapp/pages/addmatch/addmatch.js
+++ b/miniapp/pages/addmatch/addmatch.js
@@ -160,7 +160,7 @@ Page({
     const token = store.token;
     if (!cid || !userId || !token) return;
 
-    ensureSubscribe('match').then(() => {
+    ensureSubscribe('match_create').then(() => {
       if (doubles) {
         const players = this.data.players;
         const partner = players[this.data.partnerIndex];

--- a/miniapp/pages/login/index.js
+++ b/miniapp/pages/login/index.js
@@ -2,7 +2,6 @@ const { hideKeyboard } = require('../../utils/hideKeyboard');
 const userService = require('../../services/user');
 const store = require('../../store/store');
 const { t } = require('../../utils/locales');
-const ensureSubscribe = require('../../utils/ensureSubscribe');
 
 Page({
   data: { t },
@@ -16,8 +15,6 @@ Page({
       const resp = await userService.wechatLogin(res.code);
       if (resp.access_token) {
         store.setAuth(resp.access_token, resp.user_id, resp.refresh_token);
-        await ensureSubscribe('club_join');
-        await ensureSubscribe('match');
         wx.navigateBack();
       } else {
         wx.showToast({ duration: 4000, title: t.loginFailed, icon: 'none' });

--- a/miniapp/pages/manage/manage.js
+++ b/miniapp/pages/manage/manage.js
@@ -5,6 +5,7 @@ const { zh_CN } = require('../../utils/locales.js');
 const { genderText } = require('../../utils/userFormat');
 const store = require('../../store/store');
 const { withBase } = require('../../utils/format');
+const ensureSubscribe = require('../../utils/ensureSubscribe');
 
 Page({
   data: {
@@ -247,6 +248,7 @@ Page({
     const cid = store.clubId;
     const token = store.token;
     const that = this;
+    ensureSubscribe('club_manage');
     request({
       url: `${BASE_URL}/clubs/${cid}/approve`,
       method: 'POST',
@@ -297,6 +299,7 @@ Page({
     const cid = store.clubId;
     const token = store.token;
     const that = this;
+    ensureSubscribe('club_manage');
     request({
       url: `${BASE_URL}/clubs/${cid}/reject`,
       method: 'POST',

--- a/miniapp/pages/profile/profile.js
+++ b/miniapp/pages/profile/profile.js
@@ -4,7 +4,6 @@ const userService = require('../../services/user');
 const store = require('../../store/store');
 const { hideKeyboard } = require('../../utils/hideKeyboard');
 const { t } = require('../../utils/locales');
-const ensureSubscribe = require('../../utils/ensureSubscribe');
 
 Page({
   data: {
@@ -92,8 +91,6 @@ Page({
         const resp = await userService.wechatLogin(res.code);
         if (resp.access_token) {
           store.setAuth(resp.access_token, resp.user_id, resp.refresh_token);
-          await ensureSubscribe('club_join');
-          await ensureSubscribe('match');
           this.setData({ loggedIn: true });
           if (resp.just_created) {
             wx.navigateTo({ url: '/pages/editprofile/editprofile' });
@@ -115,8 +112,6 @@ Page({
   },
   async goMyClub() {
     if (!this.data.loggedIn) return;
-    await ensureSubscribe('club_join');
-    await ensureSubscribe('match');
     wx.navigateTo({ url: '/pkg_club/club-manage/index' });
   },
   goMyNotes() {

--- a/miniapp/pages/records/records.js
+++ b/miniapp/pages/records/records.js
@@ -204,6 +204,7 @@ Page({
   fetchPendings() {
     const userId = store.userId;
     const token = store.token;
+    ensureSubscribe('match_confirm');
     if (!userId || !token) return;
     const that = this;
     const placeholder = require('../../assets/base64.js').DEFAULT_AVATAR;
@@ -292,7 +293,7 @@ Page({
     const idx = e.currentTarget.dataset.id;
     const cid = e.currentTarget.dataset.club;
     const token = store.token;
-    ensureSubscribe('match').then(() => {
+    ensureSubscribe('match_create').then(() => {
       optimisticUpdate(this, 'pendingSingles', idx, () =>
         request({
           url: `${BASE_URL}/clubs/${cid}/pending_matches/${idx}/confirm`,
@@ -308,6 +309,7 @@ Page({
     const idx = e.currentTarget.dataset.id;
     const cid = e.currentTarget.dataset.club;
     const token = store.token;
+    ensureSubscribe('match_audit');
     const that = this;
     request({
       url: `${BASE_URL}/clubs/${cid}/pending_matches/${idx}/approve`,
@@ -330,6 +332,7 @@ Page({
     const idx = e.currentTarget.dataset.id;
     const cid = e.currentTarget.dataset.club;
     const token = store.token;
+    ensureSubscribe('match_audit');
     optimisticUpdate(this, 'pendingSingles', idx, () =>
       request({
         url: `${BASE_URL}/clubs/${cid}/pending_matches/${idx}/veto`,
@@ -358,7 +361,7 @@ Page({
     const idx = e.currentTarget.dataset.id;
     const cid = e.currentTarget.dataset.club;
     const token = store.token;
-    ensureSubscribe('match').then(() => {
+    ensureSubscribe('match_create').then(() => {
       optimisticUpdate(this, 'pendingDoubles', idx, () =>
         request({
           url: `${BASE_URL}/clubs/${cid}/pending_doubles/${idx}/confirm`,
@@ -374,6 +377,7 @@ Page({
     const idx = e.currentTarget.dataset.id;
     const cid = e.currentTarget.dataset.club;
     const token = store.token;
+    ensureSubscribe('match_audit');
     const that = this;
     request({
       url: `${BASE_URL}/clubs/${cid}/pending_doubles/${idx}/approve`,
@@ -396,6 +400,7 @@ Page({
     const idx = e.currentTarget.dataset.id;
     const cid = e.currentTarget.dataset.club;
     const token = store.token;
+    ensureSubscribe('match_audit');
     optimisticUpdate(this, 'pendingDoubles', idx, () =>
       request({
         url: `${BASE_URL}/clubs/${cid}/pending_doubles/${idx}/veto`,
@@ -429,7 +434,7 @@ Page({
     });
   },
   async addMatch() {
-    await ensureSubscribe('match');
+    await ensureSubscribe('match_create');
     wx.navigateTo({ url: '/pages/addmatch/addmatch' });
   },
   onPullDownRefresh() {

--- a/miniapp/pages/register/register.js
+++ b/miniapp/pages/register/register.js
@@ -3,7 +3,6 @@ const request = require('../../utils/request');
 const { hideKeyboard } = require('../../utils/hideKeyboard');
 const store = require('../../store/store');
 const { t } = require('../../utils/locales');
-const ensureSubscribe = require('../../utils/ensureSubscribe');
 
 Page({
   data: { t },
@@ -22,8 +21,6 @@ Page({
       });
       if (resp.access_token) {
         store.setAuth(resp.access_token, resp.user_id, resp.refresh_token);
-        await ensureSubscribe('club_join');
-        await ensureSubscribe('match');
         wx.navigateTo({ url: '/pages/editprofile/editprofile' });
       } else {
         wx.showToast({ duration: 4000, title: t.failed, icon: 'none' });

--- a/miniapp/pkg_club/club-manage/index.js
+++ b/miniapp/pkg_club/club-manage/index.js
@@ -4,7 +4,6 @@ const { hideKeyboard } = require('../../utils/hideKeyboard');
 const { zh_CN } = require('../../utils/locales.js');
 const { formatClubCardData } = require('../../utils/clubFormat');
 const store = require('../../store/store');
-const ensureSubscribe = require('../../utils/ensureSubscribe');
 
 Page({
   data: {
@@ -69,8 +68,6 @@ Page({
   async openClub(e) {
     const cid = e.detail.club ? e.detail.club.club_id : '';
     if (cid) {
-      await ensureSubscribe('club_join');
-      await ensureSubscribe('match');
       store.setClubId(cid);
       wx.navigateTo({ url: `/pages/manage/manage?cid=${cid}` });
     }

--- a/miniapp/pkg_club/joinclub/joinclub.js
+++ b/miniapp/pkg_club/joinclub/joinclub.js
@@ -162,7 +162,7 @@ Page({
       return;
     }
     const that = this;
-    ensureSubscribe('club_join').then(() => {
+    ensureSubscribe('join_club').then(() => {
       request({
         url: `${BASE_URL}/clubs/${cid}/join`,
         method: 'POST',

--- a/tennis/cli.py
+++ b/tennis/cli.py
@@ -242,7 +242,7 @@ def request_join(
                 send_audit_message(
                     uid,
                     u.wechat_openid,
-                    "club_join",
+                    "club_manage",
                     "俱乐部申请",
                     f"用户申请加入{club.name}，请及时审核。",
                     page=f"/pages/manage/manage?cid={club.club_id}",
@@ -296,7 +296,7 @@ def approve_member(
         send_audit_message(
             user.user_id,
             user.wechat_openid,
-            "club_join",
+            "join_club",
             "俱乐部申请",
             f"您申请加入{club.name}的请求已通过。",
             page=f"/pages/manage/manage?cid={club.club_id}",
@@ -333,7 +333,7 @@ def reject_application(
             send_audit_message(
                 user.user_id,
                 user.wechat_openid,
-                "club_join",
+                "join_club",
                 "俱乐部申请",
                 f"您申请加入{club.name}的请求未通过。",
                 page=f"/pages/manage/manage?cid={club.club_id}",
@@ -655,7 +655,7 @@ def submit_match(
             send_audit_message(
                 opp_user.user_id,
                 opp_user.wechat_openid,
-                "match",
+                "match_confirm",
                 "战绩审核",
                 "您的球友创建了与您对战的战绩，请及时确认。",
                 page="/pages/records/records?tab=1&pending=0",
@@ -696,7 +696,7 @@ def confirm_match(clubs, club_id: str, index: int, user_id: str, users=None):
                     send_audit_message(
                         uid,
                         u.wechat_openid,
-                        "match",
+                        "match_audit",
                         "战绩审核",
                         f"{club.name}成员创建了新的战绩，请及时审核。",
                         page="/pages/records/records?tab=1&pending=0",
@@ -730,7 +730,7 @@ def reject_match(clubs, club_id: str, index: int, user_id: str, users=None):
                 send_audit_message(
                     initiator.user_id,
                     initiator.wechat_openid,
-                    "match",
+                    "match_create",
                     "战绩审核",
                     "您的对手拒绝了您创建的战绩，请点击查看详情。",
                     page="/pages/records/records?tab=1&pending=1",
@@ -773,7 +773,7 @@ def veto_match(clubs, club_id: str, index: int, approver: str, users=None):
                 send_audit_message(
                     uid,
                     u.wechat_openid,
-                    "match",
+                    "match_create",
                     "战绩审核",
                     f"{club.name}否决了您的战绩，请点击查看详情。",
                     page="/pages/records/records?tab=1&pending=0",
@@ -820,7 +820,7 @@ def veto_doubles(clubs, club_id: str, index: int, approver: str, users=None):
                 send_audit_message(
                     uid,
                     u.wechat_openid,
-                    "match",
+                    "match_create",
                     "战绩审核",
                     f"{club.name}否决了您的战绩，请点击查看详情。",
                     page="/pages/records/records?tab=1&pending=1",
@@ -884,7 +884,7 @@ def submit_doubles(
                 send_audit_message(
                     opp.user_id,
                     opp.wechat_openid,
-                    "match",
+                    "match_confirm",
                     "战绩审核",
                     "您的球友创建了与您对战的战绩，请及时确认。",
                     page="/pages/records/records?tab=1&pending=1",
@@ -925,7 +925,7 @@ def confirm_doubles(clubs, club_id: str, index: int, user_id: str, users=None):
                     send_audit_message(
                         uid,
                         u.wechat_openid,
-                        "match",
+                        "match_audit",
                         "战绩审核",
                         f"{club.name}成员创建了新的战绩，请及时审核。",
                         page="/pages/records/records?tab=1&pending=1",
@@ -1025,7 +1025,7 @@ def approve_match(clubs, club_id: str, index: int, approver: str, users=None):
                     send_audit_message(
                         uid,
                         u.wechat_openid,
-                        "match",
+                        "match_create",
                         "战绩审核",
                         "新的战绩已通过并生效，请点击查看您的评分变化。",
                         page=f"/pages/records/records?tab=0&mode={mode}",


### PR DESCRIPTION
## Summary
- define new WeChat subscription scenes
- adjust backend message sending logic
- update miniapp to request authorization only when needed
- document subscription scenes in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_686a170bfe18832fb66319c67c9a99b9