### PR TITLE
Improve doubles layout

### DIFF
--- a/miniapp/components/record-card/record-card.wxss
+++ b/miniapp/components/record-card/record-card.wxss
@@ -8,8 +8,10 @@
 .row:last-child{border-bottom:none;}
 .record-card .info{flex:1;display:flex;align-items:center;flex-wrap:nowrap;flex-direction:row;}
 .record-card .info.singles{margin-left:120rpx;} /* Increased from 60rpx */
-.record-card .info.doubles{justify-content:flex-start; margin-left:120rpx;} /* Added margin-left */
+.record-card .info.doubles{justify-content:flex-start; margin-left:120rpx; flex-direction:column; align-items:flex-start;}
 .record-card .unit{display:flex;align-items:center;margin-right:10rpx;flex:1 0 auto;width:50%;}
+.record-card .info.doubles .unit{width:100%;margin-right:0;margin-top:6rpx;}
+.record-card .info.doubles .unit:first-child{margin-top:0;}
 .record-card .unit:last-child{margin-right:0;}
 .record-card .avatar{width:48rpx;height:48rpx;border-radius:50%;margin-right:12rpx;background:#ccc;flex-shrink:0;}
 .record-card .name{color:#333;font-size:26rpx;max-width:120rpx;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}


### PR DESCRIPTION
## Summary
- adjust record card layout for doubles matches so teammates stack vertically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_686a32806e8c832fa99ae12ecbb21567