### PR TITLE
Implement basic front‑end dedup for match submission

### DIFF
--- a/miniapp/pages/addmatch/addmatch.js
+++ b/miniapp/pages/addmatch/addmatch.js
@@ -35,7 +35,8 @@ Page({
     formatCodes: ['', '6_game', '4_game', 'tb10', 'tb7'],
     formatIndex: 0,
     scoreA: '',
-    scoreB: ''
+    scoreB: '',
+    submitting: false
   },
   onLoad() {
     const today = new Date().toISOString().slice(0, 10);
@@ -136,6 +137,7 @@ Page({
   onScoreB(e) { this.setData({ scoreB: e.detail.value }); },
   hideKeyboard,
   submit() {
+    if (this.data.submitting) return;
     const that = this;
     const doubles = this.data.modeIndex === 2;
     const incomplete =
@@ -159,6 +161,8 @@ Page({
     const userId = store.userId;
     const token = store.token;
     if (!cid || !userId || !token) return;
+
+    this.setData({ submitting: true });
 
     ensureSubscribe('match_create').then(() => {
       if (doubles) {
@@ -186,6 +190,9 @@ Page({
             setTimeout(() => {
               wx.navigateBack();
             }, 1000);
+          },
+          complete() {
+            that.setData({ submitting: false });
           }
         });
       } else {
@@ -208,6 +215,9 @@ Page({
             setTimeout(() => {
               wx.navigateBack();
             }, 1000);
+          },
+          complete() {
+            that.setData({ submitting: false });
           }
         });
       }

--- a/miniapp/pages/addmatch/addmatch.wxml
+++ b/miniapp/pages/addmatch/addmatch.wxml
@@ -41,7 +41,7 @@
     <input class="weui-input" type="number" placeholder="{{t.inputOppScore}}" bindinput="onScoreB" cursor-spacing="80" bindblur="hideKeyboard" />
   </view>
 
-  <button class="weui-btn weui-btn_primary submit-btn" bindtap="submit">{{t.submit}}</button>
+  <button class="weui-btn weui-btn_primary submit-btn {{submitting ? 'weui-btn_disabled' : ''}}" bindtap="submit" disabled="{{submitting}}">{{t.submit}}</button>
   </scroll-view>
 </view>
 


### PR DESCRIPTION
## Summary
- disable submit button while sending addmatch request to avoid duplicate match records

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_686e3b1d68b4832f9d0cf84aad2982eb