### PR TITLE
Update card sorting logic

### DIFF
--- a/tennis/cli.py
+++ b/tennis/cli.py
@@ -1225,7 +1225,8 @@ def get_player_match_cards(clubs, club_id: str, user_id: str):
 
     cards.sort(
         key=lambda x: (
-            x.get("approved_ts") or x["date"],
+            x.get("approved_ts")
+            or datetime.datetime.combine(x["date"], datetime.time()),
             x.get("approved_ts") or x["created_ts"],
         ),
         reverse=True,
@@ -1292,7 +1293,8 @@ def get_player_global_match_cards(player: Player) -> list[dict]:
     cards = [_match_to_card(m, player) for m in player.singles_matches]
     cards.sort(
         key=lambda x: (
-            x.get("approved_ts") or x["date"],
+            x.get("approved_ts")
+            or datetime.datetime.combine(x["date"], datetime.time()),
             x.get("approved_ts") or x["created_ts"],
         ),
         reverse=True,
@@ -1426,7 +1428,8 @@ def get_player_doubles_cards(clubs, club_id: str, user_id: str):
 
     cards.sort(
         key=lambda x: (
-            x.get("approved_ts") or x["date"],
+            x.get("approved_ts")
+            or datetime.datetime.combine(x["date"], datetime.time()),
             x.get("approved_ts") or x["created_ts"],
         ),
         reverse=True,
@@ -1539,7 +1542,8 @@ def get_player_global_doubles_cards(player: Player) -> list[dict]:
     cards = [_doubles_match_to_card(m, player) for m in player.doubles_matches]
     cards.sort(
         key=lambda x: (
-            x.get("approved_ts") or x["date"],
+            x.get("approved_ts")
+            or datetime.datetime.combine(x["date"], datetime.time()),
             x.get("approved_ts") or x["created_ts"],
         ),
         reverse=True,


### PR DESCRIPTION
## Summary
- modify sorting keys for player match and doubles cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_687106e96a1c832fb7541a2e6e1c37c7