### PR TITLE
Add sorting test for approved matches

### DIFF
--- a/tests/test_record_sorting.py
+++ b/tests/test_record_sorting.py
@@ -135,3 +135,44 @@ def test_doubles_record_sorting(tmp_path, monkeypatch):
     assert len(records) == 2
     assert records[0]["self_score"] == 6 and records[0]["opponent_score"] == 3
     assert records[1]["self_score"] == 6 and records[1]["opponent_score"] == 4
+
+
+def test_record_match_then_approved_sorting(tmp_path, monkeypatch):
+    cli, users, clubs = _setup_env(tmp_path, monkeypatch)
+
+    ts_old = datetime.datetime(2023, 1, 1, 9, 0, 0)
+
+    class DT0(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return ts_old
+
+    monkeypatch.setattr(cli.datetime, "datetime", DT0)
+    cli.record_match(clubs, "c1", "p1", "p2", 6, 4, datetime.date(2023, 1, 1), 1.0)
+
+    ts_new = datetime.datetime(2023, 1, 2, 10, 0, 0)
+
+    class DT1(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return ts_new
+
+    monkeypatch.setattr(cli.datetime, "datetime", DT1)
+    cli.submit_match(clubs, "c1", "p1", "p2", 6, 3, datetime.date(2023, 1, 2), 1.0)
+    cli.confirm_match(clubs, "c1", 0, "p2")
+    cli.approve_match(clubs, "c1", 0, "leader", users)
+
+    storage.save_users(users)
+    storage.save_data(clubs)
+
+    importlib.reload(state)
+    api = importlib.reload(importlib.import_module("tennis.api"))
+    client = TestClient(api.app)
+
+    resp = client.get("/players/p1/records")
+    assert resp.status_code == 200
+    records = resp.json()
+    assert len(records) == 2
+    assert records[0]["self_score"] == 6 and records[0]["opponent_score"] == 3
+    assert records[1]["self_score"] == 6 and records[1]["opponent_score"] == 4
+


### PR DESCRIPTION
## Summary
- add test to verify records from `record_match` are sorted after approved matches

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*


------
https://chatgpt.com/codex/tasks/task_e_6871084dcc98832fae279985a6755333