### PR TITLE
Fix DB schema check failure for Postgres

### DIFF
--- a/tennis/storage.py
+++ b/tennis/storage.py
@@ -310,7 +310,7 @@ def _init_schema(conn) -> None:
         cur.execute(
             "SELECT column_name FROM information_schema.columns WHERE table_name='club_members'"
         )
-        cols = {row[0] for row in cur.fetchall()}
+        cols = {row["column_name"] for row in cur.fetchall()}
         if 'joined' not in cols:
             cur.execute("ALTER TABLE club_members ADD COLUMN joined TEXT")
         cur.execute(


### PR DESCRIPTION
## Summary
- correct fetching of column names when initializing schema using Postgres

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_687219479e24832fa9ce1b7b465f75b9