### PR TITLE
Fix cache not refreshed on login

### DIFF
--- a/tennis/routes/users.py
+++ b/tennis/routes/users.py
@@ -60,6 +60,14 @@ def register_user_api(data: UserCreate):
 def login_api(data: LoginRequest):
     success, access, refresh, user_id = user_service.login(data.user_id, data.password)
     if success:
+        # refresh caches for the logged in user
+        user = get_user(user_id)
+        if user:
+            api.users[user.user_id] = user
+        player = get_player(user_id)
+        if player:
+            api.players[player.user_id] = player
+
         return {
             "success": True,
             "access_token": access,


### PR DESCRIPTION
## Summary
- refresh cached user and player data on login like we do for WeChat login

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*


------
https://chatgpt.com/codex/tasks/task_e_687219479e24832fa9ce1b7b465f75b9