### PR TITLE
Fix join days calculation in miniapp

### DIFF
--- a/miniapp/pages/manage/manage.js
+++ b/miniapp/pages/manage/manage.js
@@ -216,7 +216,12 @@ Page({
             });
             const now = Date.now();
             const list = Object.values(map).map(p => {
-              const joined = p.joined ? new Date(p.joined).getTime() : now;
+              const joined = p.joined
+                ? (() => {
+                    const [y, m, d] = p.joined.split('-').map(Number);
+                    return new Date(y, m - 1, d).getTime();
+                  })()
+                : now;
               const days = Math.floor((now - joined) / (1000 * 60 * 60 * 24));
               const gText = genderText(p.gender) || '-';
               p.genderText = gText;


### PR DESCRIPTION
## Summary
- correct days calculation when a user joins a club

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6876daca277c832fb3b71040dd1cd2b4