### PR TITLE
Implement player friends endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ curl -X PUT http://localhost:8000/players/USER \
 ```
 This accepts the same fields as the club specific `/clubs/{club_id}/players/{user_id}` route.
 
+Use `/players/{user_id}/friends` to retrieve aggregated interaction statistics
+with opponents and doubles partners. Each entry in the response contains the
+friend's `user_id`, name, avatar and the weighted counts and wins.
+
 Similarly, recording a match uses:
 
 ```bash

--- a/tennis/api.py
+++ b/tennis/api.py
@@ -81,6 +81,7 @@ from .rating import (
     weighted_doubles_matches,
 )
 from .services.stats import _pending_status_for_user, _club_stats
+from .services.friends import get_player_friends
 from .models import Player, Club, Match, DoublesMatch, Appointment, User
 
 # Runtime state loaded from persistent storage. ``load_data`` returns the
@@ -1009,6 +1010,12 @@ def get_global_player_doubles_records(
     if limit is not None:
         cards = cards[:limit]
     return cards
+
+
+@app.get("/players/{user_id}/friends")
+def get_player_friends_api(user_id: str):
+    """Return friend statistics aggregated from matches."""
+    return get_player_friends(user_id)
 
 
 @app.post("/clubs/{club_id}/matches")

--- a/tennis/services/friends.py
+++ b/tennis/services/friends.py
@@ -1,0 +1,55 @@
+from .exceptions import ServiceError
+from .. import storage
+from ..models import Player, DoublesMatch, Match
+
+
+def get_player_friends(user_id: str) -> list[dict[str, object]]:
+    """Return aggregated interaction stats for a player."""
+
+    player = storage.get_player(user_id)
+    if not player:
+        raise ServiceError("Player not found", 404)
+
+    friends: dict[str, dict[str, object]] = {}
+
+    def update(p: Player, win: bool, weight: float) -> None:
+        if p.user_id == user_id:
+            return
+        entry = friends.setdefault(
+            p.user_id,
+            {"user_id": p.user_id, "name": p.name, "avatar": p.avatar, "weight": 0.0, "wins": 0.0},
+        )
+        entry["weight"] += weight
+        if win:
+            entry["wins"] += weight
+
+    for m in player.singles_matches:
+        if m.player_a == player:
+            opp = m.player_b
+            win = m.score_a > m.score_b
+        else:
+            opp = m.player_a
+            win = m.score_b > m.score_a
+        update(opp, win, m.format_weight)
+
+    for m in player.doubles_matches:
+        if player in (m.player_a1, m.player_a2):
+            partner = m.player_a2 if m.player_a1 == player else m.player_a1
+            opponents = (m.player_b1, m.player_b2)
+            win = m.score_a > m.score_b
+        else:
+            partner = m.player_b2 if m.player_b1 == player else m.player_b1
+            opponents = (m.player_a1, m.player_a2)
+            win = m.score_b > m.score_a
+        update(partner, win, m.format_weight)
+        for opp in opponents:
+            update(opp, win, m.format_weight)
+
+    result = list(friends.values())
+    result.sort(key=lambda x: x["weight"], reverse=True)
+    for r in result:
+        r["weight"] = round(r["weight"], 2)
+        r["wins"] = round(r["wins"], 2)
+    return result
+
+__all__ = ["get_player_friends"]

--- a/tests/test_friends.py
+++ b/tests/test_friends.py
@@ -1,0 +1,45 @@
+import datetime
+import importlib
+from fastapi.testclient import TestClient
+import tennis.storage as storage
+import tennis.services.state as state
+
+
+def setup_env(tmp_path, monkeypatch):
+    db = tmp_path / "tennis.db"
+    monkeypatch.setattr(storage, "DB_FILE", db)
+    importlib.reload(state)
+    cli = importlib.import_module("tennis.cli")
+    users = {}
+    clubs = {}
+    cli.register_user(users, "leader", "L", "pw", allow_create=True)
+    for uid in ("p1", "p2", "p3", "p4"):
+        cli.register_user(users, uid, uid.upper(), "pw")
+    cli.create_club(users, clubs, "leader", "c1", "C1", None, None)
+    for uid in ("p1", "p2", "p3", "p4"):
+        cli.add_player(clubs, "c1", uid, uid.upper())
+    # singles matches
+    cli.record_match(clubs, "c1", "p1", "p2", 6, 4, datetime.date(2023,1,1), 1.0)
+    cli.record_match(clubs, "c1", "p3", "p1", 6, 2, datetime.date(2023,1,2), 1.0)
+    # doubles matches
+    cli.record_doubles(clubs, "c1", "p1", "p2", "p3", "p4", 6, 3, datetime.date(2023,1,3), 1.0)
+    cli.record_doubles(clubs, "c1", "p1", "p3", "p2", "p4", 4, 6, datetime.date(2023,1,4), 1.0)
+    storage.save_users(users)
+    storage.save_data(clubs)
+    importlib.reload(state)
+    api = importlib.reload(importlib.import_module("tennis.api"))
+    client = TestClient(api.app)
+    return client
+
+
+def test_player_friends_api(tmp_path, monkeypatch):
+    client = setup_env(tmp_path, monkeypatch)
+    data = client.get("/players/p1/friends").json()
+    assert len(data) == 3
+    by_id = {d["user_id"]: d for d in data}
+    assert by_id["p2"]["weight"] == 3.0
+    assert by_id["p2"]["wins"] == 2.0
+    assert by_id["p3"]["weight"] == 3.0
+    assert by_id["p3"]["wins"] == 1.0
+    assert by_id["p4"]["weight"] == 2.0
+    assert by_id["p4"]["wins"] == 1.0


### PR DESCRIPTION
## Summary
- add service module for friend stats
- expose `/players/{user_id}/friends` endpoint
- test friend stats API
- document endpoint in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_687750726eb4832fb41c8f4e2c88ee6b