### PR TITLE
Fix missing avatar URL on friends page

### DIFF
--- a/miniapp/pages/myfriends/myfriends.js
+++ b/miniapp/pages/myfriends/myfriends.js
@@ -2,6 +2,7 @@ const friendService = require('../../services/friend');
 const store = require('../../store/store');
 const { hideKeyboard } = require('../../utils/hideKeyboard');
 const { t } = require('../../utils/locales');
+const { withBase } = require('../../utils/format');
 const IMAGES = require('../../assets/base64.js');
 
 Page({
@@ -21,6 +22,7 @@ Page({
     friendService.getFriends(uid)
       .then(res => {
         const list = (res || []).map(item => {
+          item.avatar = withBase(item.avatar || item.avatar_url);
           if (!item.matches_against && item.weight !== undefined) {
             const winRate = item.weight ? ((item.wins || 0) / item.weight * 100).toFixed(1) : 0;
             item.matches_against = { count: item.weight, win_rate: winRate };

--- a/tennis/api.py
+++ b/tennis/api.py
@@ -1013,9 +1013,12 @@ def get_global_player_doubles_records(
 
 
 @app.get("/players/{user_id}/friends")
-def get_player_friends_api(user_id: str):
+def get_player_friends_api(user_id: str, request: Request):
     """Return friend statistics aggregated from matches."""
-    return get_player_friends(user_id)
+    friends = get_player_friends(user_id)
+    for f in friends:
+        f["avatar_url"] = absolute_url(request, f.get("avatar"))
+    return friends
 
 
 @app.post("/clubs/{club_id}/matches")


### PR DESCRIPTION
## Summary
- provide `avatar_url` in `/players/{user_id}/friends` API
- normalize avatar URLs on the `myfriends` page so images load

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6877974755e4832f9ae8064508ff4a25