### PR TITLE
Add partner stats in friends service

### DIFF
--- a/tennis/api.py
+++ b/tennis/api.py
@@ -1018,6 +1018,8 @@ def get_player_friends_api(user_id: str, request: Request):
     friends = get_player_friends(user_id)
     for f in friends:
         f["avatar_url"] = absolute_url(request, f.get("avatar"))
+        f.setdefault("partner_games", 0.0)
+        f.setdefault("partner_wins", 0.0)
     return friends
 
 

--- a/tennis/services/friends.py
+++ b/tennis/services/friends.py
@@ -12,16 +12,28 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
 
     friends: dict[str, dict[str, object]] = {}
 
-    def update(p: Player, win: bool, weight: float) -> None:
+    def update(p: Player, win: bool, weight: float, partner: bool = False) -> None:
         if p.user_id == user_id:
             return
         entry = friends.setdefault(
             p.user_id,
-            {"user_id": p.user_id, "name": p.name, "avatar": p.avatar, "weight": 0.0, "wins": 0.0},
+            {
+                "user_id": p.user_id,
+                "name": p.name,
+                "avatar": p.avatar,
+                "weight": 0.0,
+                "wins": 0.0,
+                "partner_games": 0.0,
+                "partner_wins": 0.0,
+            },
         )
         entry["weight"] += weight
         if win:
             entry["wins"] += weight
+        if partner:
+            entry["partner_games"] += weight
+            if win:
+                entry["partner_wins"] += weight
 
     for m in player.singles_matches:
         if m.player_a == player:
@@ -41,7 +53,7 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
             partner = m.player_b2 if m.player_b1 == player else m.player_b1
             opponents = (m.player_a1, m.player_a2)
             win = m.score_b > m.score_a
-        update(partner, win, m.format_weight)
+        update(partner, win, m.format_weight, partner=True)
         for opp in opponents:
             update(opp, win, m.format_weight)
 
@@ -50,6 +62,8 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
     for r in result:
         r["weight"] = round(r["weight"], 2)
         r["wins"] = round(r["wins"], 2)
+        r["partner_games"] = round(r["partner_games"], 2)
+        r["partner_wins"] = round(r["partner_wins"], 2)
     return result
 
 __all__ = ["get_player_friends"]

--- a/tests/test_friends.py
+++ b/tests/test_friends.py
@@ -39,6 +39,8 @@ def test_player_friends_api(tmp_path, monkeypatch):
     by_id = {d["user_id"]: d for d in data}
     assert by_id["p2"]["weight"] == 3.0
     assert by_id["p2"]["wins"] == 2.0
+    assert by_id["p2"]["partner_games"] == 1.0
+    assert by_id["p2"]["partner_wins"] == 1.0
     assert by_id["p3"]["weight"] == 3.0
     assert by_id["p3"]["wins"] == 1.0
     assert by_id["p4"]["weight"] == 2.0


### PR DESCRIPTION
## Summary
- track doubles partner data in `get_player_friends`
- expose partner stats in the friends API
- test partner statistics for player friends

## Testing
- `pytest -q tests/test_friends.py::test_player_friends_api` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_6878ad80b0d4832fae8facb0d5435936