### PR TITLE
Add partner text check in friends list test

### DIFF
--- a/miniapp/test/friends.test.js
+++ b/miniapp/test/friends.test.js
@@ -35,6 +35,12 @@ test('friends page shows entries', async () => {
   expect(items[0].querySelector('.name').innerHTML).toBe('F1');
   expect(items[1].querySelector('.name').innerHTML).toBe('F2');
   expect(items[0].querySelectorAll('.icon').length).toBe(2);
+  // verify partner information is displayed when available
+  const partnerText1 = items[0].querySelectorAll('.text')[1].innerHTML;
+  expect(partnerText1).toBe('搭档1场');
+  // verify absence of partner information displays fallback text
+  const partnerText2 = items[1].querySelectorAll('.text')[1].innerHTML;
+  expect(partnerText2).toBe('尚未搭档');
   const summary = comp.dom.querySelector('.summary').innerHTML;
   expect(summary).toBe('您共与2位球友对战/搭档过：');
 });


### PR DESCRIPTION
## Summary
- extend `friends.test.js` to verify partner text is shown
- check fallback text when partner info is missing

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878aed8aef0832f82ce3b88840a2cfc