### PR TITLE
Add singles and doubles friend stats

### DIFF
--- a/miniapp/pages/myfriends/myfriends.js
+++ b/miniapp/pages/myfriends/myfriends.js
@@ -23,6 +23,14 @@ Page({
       .then(res => {
         const list = (res || []).map(item => {
           item.avatar = withBase(item.avatar || item.avatar_url);
+          if (!item.matches_singles && item.singles_weight !== undefined) {
+            const winRate = item.singles_weight ? ((item.singles_wins || 0) / item.singles_weight * 100).toFixed(1) : 0;
+            item.matches_singles = { count: item.singles_weight, win_rate: winRate };
+          }
+          if (!item.matches_doubles && item.doubles_weight !== undefined) {
+            const winRate = item.doubles_weight ? ((item.doubles_wins || 0) / item.doubles_weight * 100).toFixed(1) : 0;
+            item.matches_doubles = { count: item.doubles_weight, win_rate: winRate };
+          }
           if (!item.matches_against && item.weight !== undefined) {
             const winRate = item.weight ? ((item.wins || 0) / item.weight * 100).toFixed(1) : 0;
             item.matches_against = { count: item.weight, win_rate: winRate };

--- a/miniapp/pages/myfriends/myfriends.wxml
+++ b/miniapp/pages/myfriends/myfriends.wxml
@@ -12,19 +12,31 @@
         </view>
         <view class="stats">
           <view class="col">
-            <view class="icon">⚔️</view>
+            <view class="icon">⚔️单打对战</view>
             <view class="text">
-              <block wx:if="{{item.matches_against && item.matches_against.count}}">
-                交手{{item.matches_against.count}}场
+              <block wx:if="{{item.matches_singles && item.matches_singles.count}}">
+                交手{{item.matches_singles.count}}场
               </block>
               <block wx:else>{{t.noAgainst}}</block>
             </view>
-            <view class="rate" wx:if="{{item.matches_against && item.matches_against.count}}">
-              胜率{{item.matches_against.win_rate}}%
+            <view class="rate" wx:if="{{item.matches_singles && item.matches_singles.count}}">
+              胜率{{item.matches_singles.win_rate}}%
             </view>
           </view>
           <view class="col">
-            <view class="icon">🤝</view>
+            <view class="icon">⚔️双打对战</view>
+            <view class="text">
+              <block wx:if="{{item.matches_doubles && item.matches_doubles.count}}">
+                交手{{item.matches_doubles.count}}场
+              </block>
+              <block wx:else>{{t.noAgainst}}</block>
+            </view>
+            <view class="rate" wx:if="{{item.matches_doubles && item.matches_doubles.count}}">
+              胜率{{item.matches_doubles.win_rate}}%
+            </view>
+          </view>
+          <view class="col">
+            <view class="icon">🤝双打合作</view>
             <view class="text">
               <block wx:if="{{item.matches_partnered && item.matches_partnered.count}}">
                 搭档{{item.matches_partnered.count}}场

--- a/miniapp/test/friends.test.js
+++ b/miniapp/test/friends.test.js
@@ -9,8 +9,24 @@ global.getApp = () => ({ globalData: { BASE_URL: 'http://server' } });
 global.wx = { navigateTo: jest.fn() };
 
 const sampleData = [
-  { user_id: 'f1', name: 'F1', avatar: '/f1.png', weight: 3, wins: 2, partner_games: 1 },
-  { user_id: 'f2', name: 'F2', avatar: '/f2.png', weight: 1, wins: 0 }
+  {
+    user_id: 'f1',
+    name: 'F1',
+    avatar: '/f1.png',
+    singles_weight: 1,
+    singles_wins: 1,
+    doubles_weight: 1,
+    doubles_wins: 0,
+    partner_games: 1,
+    partner_wins: 1,
+  },
+  {
+    user_id: 'f2',
+    name: 'F2',
+    avatar: '/f2.png',
+    singles_weight: 1,
+    singles_wins: 0,
+  },
 ];
 
 friendService.getFriends = jest.fn().mockResolvedValue(sampleData);
@@ -34,12 +50,12 @@ test('friends page shows entries', async () => {
   expect(items.length).toBe(2);
   expect(items[0].querySelector('.name').innerHTML).toBe('F1');
   expect(items[1].querySelector('.name').innerHTML).toBe('F2');
-  expect(items[0].querySelectorAll('.icon').length).toBe(2);
+  expect(items[0].querySelectorAll('.icon').length).toBe(3);
   // verify partner information is displayed when available
-  const partnerText1 = items[0].querySelectorAll('.text')[1].innerHTML;
+  const partnerText1 = items[0].querySelectorAll('.text')[2].innerHTML;
   expect(partnerText1).toBe('搭档1场');
   // verify absence of partner information displays fallback text
-  const partnerText2 = items[1].querySelectorAll('.text')[1].innerHTML;
+  const partnerText2 = items[1].querySelectorAll('.text')[2].innerHTML;
   expect(partnerText2).toBe('尚未搭档');
   const summary = comp.dom.querySelector('.summary').innerHTML;
   expect(summary).toBe('您共与2位球友对战/搭档过：');

--- a/tennis/api.py
+++ b/tennis/api.py
@@ -1018,8 +1018,15 @@ def get_player_friends_api(user_id: str, request: Request):
     friends = get_player_friends(user_id)
     for f in friends:
         f["avatar_url"] = absolute_url(request, f.get("avatar"))
-        f.setdefault("partner_games", 0.0)
-        f.setdefault("partner_wins", 0.0)
+        for k in (
+            "partner_games",
+            "partner_wins",
+            "singles_weight",
+            "singles_wins",
+            "doubles_weight",
+            "doubles_wins",
+        ):
+            f.setdefault(k, 0.0)
     return friends
 
 

--- a/tennis/services/friends.py
+++ b/tennis/services/friends.py
@@ -12,7 +12,15 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
 
     friends: dict[str, dict[str, object]] = {}
 
-    def update(p: Player, win: bool, weight: float, partner: bool = False) -> None:
+    def update(
+        p: Player,
+        win: bool,
+        weight: float,
+        *,
+        singles: bool = False,
+        doubles: bool = False,
+        partner: bool = False,
+    ) -> None:
         if p.user_id == user_id:
             return
         entry = friends.setdefault(
@@ -23,6 +31,10 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
                 "avatar": p.avatar,
                 "weight": 0.0,
                 "wins": 0.0,
+                "singles_weight": 0.0,
+                "singles_wins": 0.0,
+                "doubles_weight": 0.0,
+                "doubles_wins": 0.0,
                 "partner_games": 0.0,
                 "partner_wins": 0.0,
             },
@@ -30,6 +42,14 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
         entry["weight"] += weight
         if win:
             entry["wins"] += weight
+        if singles:
+            entry["singles_weight"] += weight
+            if win:
+                entry["singles_wins"] += weight
+        if doubles:
+            entry["doubles_weight"] += weight
+            if win:
+                entry["doubles_wins"] += weight
         if partner:
             entry["partner_games"] += weight
             if win:
@@ -42,7 +62,7 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
         else:
             opp = m.player_a
             win = m.score_b > m.score_a
-        update(opp, win, m.format_weight)
+        update(opp, win, m.format_weight, singles=True)
 
     for m in player.doubles_matches:
         if player in (m.player_a1, m.player_a2):
@@ -53,15 +73,19 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
             partner = m.player_b2 if m.player_b1 == player else m.player_b1
             opponents = (m.player_a1, m.player_a2)
             win = m.score_b > m.score_a
-        update(partner, win, m.format_weight, partner=True)
+        update(partner, win, m.format_weight, doubles=True, partner=True)
         for opp in opponents:
-            update(opp, win, m.format_weight)
+            update(opp, win, m.format_weight, doubles=True)
 
     result = list(friends.values())
     result.sort(key=lambda x: x["weight"], reverse=True)
     for r in result:
         r["weight"] = round(r["weight"], 2)
         r["wins"] = round(r["wins"], 2)
+        r["singles_weight"] = round(r["singles_weight"], 2)
+        r["singles_wins"] = round(r["singles_wins"], 2)
+        r["doubles_weight"] = round(r["doubles_weight"], 2)
+        r["doubles_wins"] = round(r["doubles_wins"], 2)
         r["partner_games"] = round(r["partner_games"], 2)
         r["partner_wins"] = round(r["partner_wins"], 2)
     return result

--- a/tests/test_friends.py
+++ b/tests/test_friends.py
@@ -41,7 +41,19 @@ def test_player_friends_api(tmp_path, monkeypatch):
     assert by_id["p2"]["wins"] == 2.0
     assert by_id["p2"]["partner_games"] == 1.0
     assert by_id["p2"]["partner_wins"] == 1.0
+    assert by_id["p2"]["singles_weight"] == 1.0
+    assert by_id["p2"]["singles_wins"] == 1.0
+    assert by_id["p2"]["doubles_weight"] == 1.0
+    assert by_id["p2"]["doubles_wins"] == 0.0
     assert by_id["p3"]["weight"] == 3.0
     assert by_id["p3"]["wins"] == 1.0
+    assert by_id["p3"]["partner_games"] == 1.0
+    assert by_id["p3"]["partner_wins"] == 0.0
+    assert by_id["p3"]["singles_weight"] == 1.0
+    assert by_id["p3"]["singles_wins"] == 0.0
+    assert by_id["p3"]["doubles_weight"] == 1.0
+    assert by_id["p3"]["doubles_wins"] == 1.0
     assert by_id["p4"]["weight"] == 2.0
     assert by_id["p4"]["wins"] == 1.0
+    assert by_id["p4"]["doubles_weight"] == 2.0
+    assert by_id["p4"]["doubles_wins"] == 1.0


### PR DESCRIPTION
## Summary
- track singles and doubles opponent stats in backend
- expose new stats from `/players/{id}/friends`
- show singles and doubles breakdown on the friends page
- update tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*
- `npm --prefix miniapp test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d1683d44832fb4785c686ead228d