### PR TITLE
Remove age from player card

### DIFF
--- a/miniapp/pages/playercard/playercard.js
+++ b/miniapp/pages/playercard/playercard.js
@@ -52,9 +52,10 @@ Page({
             : (doublesCount ? Number(doublesCount).toFixed(2) : '--')
         };
         const extra = formatExtraLines(user);
+        const line1 = extra.line1.replace(/(?:^|·)\d+岁/, '');
         that.setData({
           user,
-          infoLine1: extra.line1,
+          infoLine1: line1,
           infoLine2: extra.line2,
         });
         that.setData({


### PR DESCRIPTION
## Summary
- stop exporting unused helper and rely on original formatExtraLines
- strip age from the info line when rendering the player card

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*


------
https://chatgpt.com/codex/tasks/task_e_688415108fec832f9669dd49eb036977