### PR TITLE
Add matches sorting to leaderboard

### DIFF
--- a/miniapp/pages/leaderboard/leaderboard.js
+++ b/miniapp/pages/leaderboard/leaderboard.js
@@ -16,11 +16,15 @@ Page({
       clubs: [],
       mode: 'Singles',
       gender: 'All',
-      region: ''
+      region: '',
+      sort: 'rating'
     },
     genderOptions: ['男子&女子', '男子', '女子'],
     genderIndex: 0,
     genderText: '男子&女子',
+    sortOptions: ['评分', '场次'],
+    sortIndex: 0,
+    sortText: '评分',
     region: ['-', '-', '-'],
     regionText: '全国',
     page: 1,
@@ -129,6 +133,14 @@ Page({
     this.setData({ genderIndex: index, genderText, filter, page: 1, players: [], finished: false });
     this.fetchList(filter);
   },
+  onSortChange(e) {
+    const index = Number(e.detail.value);
+    const sort = index === 1 ? 'matches' : 'rating';
+    const sortText = this.data.sortOptions[index] || '评分';
+    const filter = { ...this.data.filter, sort };
+    this.setData({ sortIndex: index, sortText, filter, page: 1, players: [], finished: false });
+    this.fetchList(filter);
+  },
   onRegionChange(e) {
     const region = e.detail.value;
     const parts = region.filter(r => r && r !== '-');
@@ -148,6 +160,7 @@ Page({
     if (filter.gender && filter.gender !== 'All') params.gender = filter.gender;
     if (filter.mode === 'Doubles') params.doubles = true;
     if (filter.region) params.region = filter.region;
+    if (filter.sort === 'matches') params.sort = 'matches';
     params.limit = limit;
     if (offset) params.offset = offset;
     if (clubs.length) params.club = clubs.join(',');
@@ -160,6 +173,11 @@ Page({
           p.rating = rating != null ? Number(rating).toFixed(3) : '--';
           if (p.weighted_singles_matches != null) p.weighted_singles_matches = p.weighted_singles_matches.toFixed(2);
           if (p.weighted_doubles_matches != null) p.weighted_doubles_matches = p.weighted_doubles_matches.toFixed(2);
+          if (that.data.filter.sort === 'matches') {
+            p.display = that.data.filter.mode === 'Doubles' ? p.weighted_doubles_matches : p.weighted_singles_matches;
+          } else {
+            p.display = p.rating;
+          }
           p.avatar = withBase(p.avatar || p.avatar_url);
         });
         if (that.data.page === 1) {

--- a/miniapp/pages/leaderboard/leaderboard.wxml
+++ b/miniapp/pages/leaderboard/leaderboard.wxml
@@ -4,6 +4,9 @@
 </view>
 
 <view class="filter-bar">
+  <picker mode="selector" range="{{sortOptions}}" value="{{sortIndex}}" bindchange="onSortChange">
+    <view class="filter-item">{{sortText}}</view>
+  </picker>
   <picker mode="selector" range="{{clubs}}" range-key="name" value="{{selectedClubIndex}}" bindchange="onClubSelect">
     <view class="filter-item">{{selectedClubText}}</view>
   </picker>
@@ -42,7 +45,7 @@
         <view class="name">{{item.name}}</view>
         <view class="meta">{{item.gender=='M'?'男':item.gender=='F'?'女':'-'}} · {{filter.mode === 'Singles' ? '单打场次:' : '双打场次:'}} {{filter.mode === 'Singles' ? item.weighted_singles_matches : item.weighted_doubles_matches}}</view>
       </view>
-      <view class="score">{{item.rating}}</view>
+      <view class="score">{{item.display}}</view>
     </view>
   </block>
 </view>

--- a/tennis/api.py
+++ b/tennis/api.py
@@ -546,8 +546,15 @@ def list_players(
             entry["singles_rating"] = rating
         players.append(entry)
 
-    key = "doubles_rating" if doubles else "singles_rating"
-    players.sort(key=lambda x: x.get(key, float('-inf')) if x.get(key) is not None else float('-inf'), reverse=True)
+    if sort == "matches":
+        key = "weighted_doubles_matches" if doubles else "weighted_singles_matches"
+        players.sort(key=lambda x: x.get(key, float('-inf')), reverse=True)
+    else:
+        key = "doubles_rating" if doubles else "singles_rating"
+        players.sort(
+            key=lambda x: x.get(key, float("-inf")) if x.get(key) is not None else float("-inf"),
+            reverse=True,
+        )
     return players
 
 
@@ -629,6 +636,7 @@ def list_all_players(
     club: str | None = None,
     doubles: bool = False,
     region: str | None = None,
+    sort: str = "rating",
     limit: int | None = None,
     offset: int = 0,
 ):
@@ -748,6 +756,7 @@ def leaderboard_full(
     club: str | None = None,
     doubles: bool = False,
     region: str | None = None,
+    sort: str = "rating",
     limit: int | None = None,
     offset: int = 0,
 ):
@@ -777,6 +786,7 @@ def leaderboard_full(
             club=club,
             doubles=doubles,
             region=region,
+            sort=sort,
             limit=limit,
             offset=offset,
         )

--- a/tests/test_leaderboard_full_api.py
+++ b/tests/test_leaderboard_full_api.py
@@ -65,3 +65,50 @@ def test_global_leaderboard_includes_orphan(tmp_path, monkeypatch):
     assert resp.status_code == 200
     ids = [p["user_id"] for p in resp.json()["players"]]
     assert "solo" in ids
+
+
+def test_leaderboard_full_sort_matches(tmp_path, monkeypatch):
+    api, client = setup_db(tmp_path, monkeypatch)
+
+    for uid, allow in (("leader", True), ("p1", False), ("p2", False)):
+        client.post(
+            "/users",
+            json={"user_id": uid, "name": uid.upper(), "password": "pw", "allow_create": allow},
+        )
+
+    token_leader = client.post("/login", json={"user_id": "leader", "password": "pw"}).json()["token"]
+    token_p1 = client.post("/login", json={"user_id": "p1", "password": "pw"}).json()["token"]
+    token_p2 = client.post("/login", json={"user_id": "p2", "password": "pw"}).json()["token"]
+
+    client.post(
+        "/clubs",
+        json={"club_id": "c1", "name": "C1", "user_id": "leader", "token": token_leader},
+    )
+    client.post(
+        "/clubs/c1/players",
+        json={"user_id": "p1", "name": "P1", "token": token_p1},
+    )
+    client.post(
+        "/clubs/c1/players",
+        json={"user_id": "p2", "name": "P2", "token": token_p2},
+    )
+
+    club = storage.get_club("c1")
+    import datetime
+    from tennis.models import Match
+    p1 = club.members["p1"]
+    p2 = club.members["p2"]
+    today = datetime.date.today()
+    match = Match(date=today, player_a=p1, player_b=p2, score_a=6, score_b=4, club_id="c1")
+    p1.singles_matches.append(match)
+    p2.singles_matches.append(match)
+    p2.singles_matches.append(match)
+    for m in club.members.values():
+        m.singles_rating = 1000
+    storage.save_club(club)
+
+    resp = client.get("/leaderboard_full?club=c1&sort=matches")
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = [p["user_id"] for p in data["players"]]
+    assert ids[0] == "p2"


### PR DESCRIPTION
## Summary
- allow sorting by match count in `/players` and `/leaderboard_full`
- support new `sort` query parameter on backend
- expose rating/matches toggle in leaderboard page
- adapt miniapp UI to show value based on selection
- add regression tests for new sorting option

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_68841c0c8924832fb4c8866c05e59f04