### PR TITLE
Display friend net score

### DIFF
--- a/miniapp/pages/myfriends/myfriends.js
+++ b/miniapp/pages/myfriends/myfriends.js
@@ -2,7 +2,7 @@ const friendService = require('../../services/friend');
 const store = require('../../store/store');
 const { hideKeyboard } = require('../../utils/hideKeyboard');
 const { t } = require('../../utils/locales');
-const { withBase } = require('../../utils/format');
+const { withBase, formatScoreDiff } = require('../../utils/format');
 const IMAGES = require('../../assets/base64.js');
 
 Page({
@@ -24,20 +24,28 @@ Page({
         const list = (res || []).map(item => {
           item.avatar = withBase(item.avatar || item.avatar_url);
           if (!item.matches_singles && item.singles_weight !== undefined) {
-            const winRate = item.singles_weight ? ((item.singles_wins || 0) / item.singles_weight * 100).toFixed(1) : 0;
-            item.matches_singles = { count: item.singles_weight, win_rate: winRate };
+            const info = formatScoreDiff(item.singles_score_diff);
+            item.matches_singles = {
+              count: item.singles_weight,
+              display: info.display,
+              cls: info.cls,
+            };
           }
           if (!item.matches_doubles && item.doubles_weight !== undefined) {
-            const winRate = item.doubles_weight ? ((item.doubles_wins || 0) / item.doubles_weight * 100).toFixed(1) : 0;
-            item.matches_doubles = { count: item.doubles_weight, win_rate: winRate };
-          }
-          if (!item.matches_against && item.weight !== undefined) {
-            const winRate = item.weight ? ((item.wins || 0) / item.weight * 100).toFixed(1) : 0;
-            item.matches_against = { count: item.weight, win_rate: winRate };
+            const info = formatScoreDiff(item.doubles_score_diff);
+            item.matches_doubles = {
+              count: item.doubles_weight,
+              display: info.display,
+              cls: info.cls,
+            };
           }
           if (!item.matches_partnered && item.partner_games !== undefined) {
-            const winRate = item.partner_games ? ((item.partner_wins || 0) / item.partner_games * 100).toFixed(1) : 0;
-            item.matches_partnered = { count: item.partner_games, win_rate: winRate };
+            const info = formatScoreDiff(item.partner_score_diff);
+            item.matches_partnered = {
+              count: item.partner_games,
+              display: info.display,
+              cls: info.cls,
+            };
           }
           return item;
         });

--- a/miniapp/pages/myfriends/myfriends.wxml
+++ b/miniapp/pages/myfriends/myfriends.wxml
@@ -19,9 +19,7 @@
               </block>
               <block wx:else>{{t.noAgainst}}</block>
             </view>
-            <view class="rate" wx:if="{{item.matches_singles && item.matches_singles.count}}">
-              胜率{{item.matches_singles.win_rate}}%
-            </view>
+            <view class="score {{item.matches_singles.cls}}">{{item.matches_singles.display}}</view>
           </view>
           <view class="col">
             <view class="icon">⚔️双打</view>
@@ -31,9 +29,7 @@
               </block>
               <block wx:else>{{t.noAgainst}}</block>
             </view>
-            <view class="rate" wx:if="{{item.matches_doubles && item.matches_doubles.count}}">
-              胜率{{item.matches_doubles.win_rate}}%
-            </view>
+            <view class="score {{item.matches_doubles.cls}}">{{item.matches_doubles.display}}</view>
           </view>
           <view class="col">
             <view class="icon">🤝双打</view>
@@ -43,9 +39,7 @@
               </block>
               <block wx:else>{{t.noPartner}}</block>
             </view>
-            <view class="rate" wx:if="{{item.matches_partnered && item.matches_partnered.count}}">
-              胜率{{item.matches_partnered.win_rate}}%
-            </view>
+            <view class="score {{item.matches_partnered.cls}}">{{item.matches_partnered.display}}</view>
           </view>
         </view>
       </view>

--- a/miniapp/pages/myfriends/myfriends.wxss
+++ b/miniapp/pages/myfriends/myfriends.wxss
@@ -11,4 +11,7 @@ page{background:#f5f5f5;}
 .icon{font-size:26rpx;margin-bottom:8rpx;}
 .text{font-size:24rpx;color:#666;}
 .rate{font-size:24rpx;color:#666;margin-top:4rpx;}
+.score{font-size:24rpx;margin-top:4rpx;}
+.pos{color:green;}
+.neutral{color:gray;}
 .empty{text-align:center;color:#999;padding:40rpx 0;}

--- a/miniapp/test/friends.test.js
+++ b/miniapp/test/friends.test.js
@@ -15,10 +15,13 @@ const sampleData = [
     avatar: '/f1.png',
     singles_weight: 1,
     singles_wins: 1,
+    singles_score_diff: 2,
     doubles_weight: 1,
     doubles_wins: 0,
+    doubles_score_diff: -1,
     partner_games: 1,
     partner_wins: 1,
+    partner_score_diff: 3,
   },
   {
     user_id: 'f2',
@@ -26,6 +29,7 @@ const sampleData = [
     avatar: '/f2.png',
     singles_weight: 1,
     singles_wins: 0,
+    singles_score_diff: -2,
   },
 ];
 
@@ -57,6 +61,10 @@ test('friends page shows entries', async () => {
   // verify absence of partner information displays fallback text
   const partnerText2 = items[1].querySelectorAll('.text')[2].innerHTML;
   expect(partnerText2).toBe('尚未搭档');
+  const score1 = items[0].querySelectorAll('.score')[0].innerHTML;
+  expect(score1).toBe('+2.000');
+  const score2 = items[1].querySelectorAll('.score')[0].innerHTML;
+  expect(score2).toBe('-2.000');
   const summary = comp.dom.querySelector('.summary').innerHTML;
   expect(summary).toBe('您共与2位球友对战/搭档过：');
 });

--- a/miniapp/utils/format.js
+++ b/miniapp/utils/format.js
@@ -18,4 +18,15 @@ function withBase(path) {
   return getApp().globalData.BASE_URL + path;
 }
 
-module.exports = { formatRating, formatGames, withBase };
+function formatScoreDiff(value) {
+  const num = Number(value);
+  if (!value || Number.isNaN(num)) {
+    return { display: '0.000', cls: 'neutral' };
+  }
+  const abs = Math.abs(num).toFixed(3);
+  const sign = num > 0 ? '+' : num < 0 ? '-' : '';
+  const cls = num === 0 ? 'neutral' : 'pos';
+  return { display: sign + abs, cls };
+}
+
+module.exports = { formatRating, formatGames, withBase, formatScoreDiff };

--- a/tennis/api.py
+++ b/tennis/api.py
@@ -1036,6 +1036,9 @@ def get_player_friends_api(user_id: str, request: Request):
             "singles_wins",
             "doubles_weight",
             "doubles_wins",
+            "singles_score_diff",
+            "doubles_score_diff",
+            "partner_score_diff",
         ):
             f.setdefault(k, 0.0)
     return friends

--- a/tennis/services/friends.py
+++ b/tennis/services/friends.py
@@ -20,6 +20,7 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
         singles: bool = False,
         doubles: bool = False,
         partner: bool = False,
+        score_diff: float = 0.0,
     ) -> None:
         if p.user_id == user_id:
             return
@@ -37,6 +38,9 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
                 "doubles_wins": 0.0,
                 "partner_games": 0.0,
                 "partner_wins": 0.0,
+                "singles_score_diff": 0.0,
+                "doubles_score_diff": 0.0,
+                "partner_score_diff": 0.0,
             },
         )
         entry["weight"] += weight
@@ -46,36 +50,43 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
             entry["singles_weight"] += weight
             if win:
                 entry["singles_wins"] += weight
+            entry["singles_score_diff"] += score_diff
         if doubles:
             entry["doubles_weight"] += weight
             if win:
                 entry["doubles_wins"] += weight
+            entry["doubles_score_diff"] += score_diff
         if partner:
             entry["partner_games"] += weight
             if win:
                 entry["partner_wins"] += weight
+            entry["partner_score_diff"] += score_diff
 
     for m in player.singles_matches:
         if m.player_a == player:
             opp = m.player_b
             win = m.score_a > m.score_b
+            diff = (m.score_a - m.score_b) * m.format_weight
         else:
             opp = m.player_a
             win = m.score_b > m.score_a
-        update(opp, win, m.format_weight, singles=True)
+            diff = (m.score_b - m.score_a) * m.format_weight
+        update(opp, win, m.format_weight, singles=True, score_diff=diff)
 
     for m in player.doubles_matches:
         if player in (m.player_a1, m.player_a2):
             partner = m.player_a2 if m.player_a1 == player else m.player_a1
             opponents = (m.player_b1, m.player_b2)
             win = m.score_a > m.score_b
+            diff = (m.score_a - m.score_b) * m.format_weight
         else:
             partner = m.player_b2 if m.player_b1 == player else m.player_b1
             opponents = (m.player_a1, m.player_a2)
             win = m.score_b > m.score_a
-        update(partner, win, m.format_weight, doubles=True, partner=True)
+            diff = (m.score_b - m.score_a) * m.format_weight
+        update(partner, win, m.format_weight, doubles=True, partner=True, score_diff=diff)
         for opp in opponents:
-            update(opp, win, m.format_weight, doubles=True)
+            update(opp, win, m.format_weight, doubles=True, score_diff=diff)
 
     result = list(friends.values())
     result.sort(key=lambda x: x["weight"], reverse=True)
@@ -88,6 +99,9 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
         r["doubles_wins"] = round(r["doubles_wins"], 2)
         r["partner_games"] = round(r["partner_games"], 2)
         r["partner_wins"] = round(r["partner_wins"], 2)
+        r["singles_score_diff"] = round(r["singles_score_diff"], 3)
+        r["doubles_score_diff"] = round(r["doubles_score_diff"], 3)
+        r["partner_score_diff"] = round(r["partner_score_diff"], 3)
     return result
 
 __all__ = ["get_player_friends"]


### PR DESCRIPTION
## Summary
- compute net score differential for each friend on backend
- expose new score fields in the friends API
- show net score instead of win rate on the My Friends page
- adjust page styles and test for new display
- add helper to format score differentials

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688427ce3818832fb0721e14233f4941