### PR TITLE
Update leaderboard display logic

### DIFF
--- a/miniapp/pages/leaderboard/leaderboard.js
+++ b/miniapp/pages/leaderboard/leaderboard.js
@@ -173,11 +173,7 @@ Page({
           p.rating = rating != null ? Number(rating).toFixed(3) : '--';
           if (p.weighted_singles_matches != null) p.weighted_singles_matches = p.weighted_singles_matches.toFixed(2);
           if (p.weighted_doubles_matches != null) p.weighted_doubles_matches = p.weighted_doubles_matches.toFixed(2);
-          if (that.data.filter.sort === 'matches') {
-            p.display = that.data.filter.mode === 'Doubles' ? p.weighted_doubles_matches : p.weighted_singles_matches;
-          } else {
-            p.display = p.rating;
-          }
+          p.display = p.rating;
           p.avatar = withBase(p.avatar || p.avatar_url);
         });
         if (that.data.page === 1) {


### PR DESCRIPTION
## Summary
- keep rating display unchanged when sorting by match count

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_68842cd48a3c832fa204f58b607bc531