### PR TITLE
Fix net score color for negative values

### DIFF
--- a/miniapp/utils/format.js
+++ b/miniapp/utils/format.js
@@ -25,7 +25,7 @@ function formatScoreDiff(value) {
   }
   const abs = Math.abs(num).toFixed(3);
   const sign = num > 0 ? '+' : num < 0 ? '-' : '';
-  const cls = num === 0 ? 'neutral' : 'pos';
+  const cls = num > 0 ? 'pos' : num < 0 ? 'neg' : 'neutral';
   return { display: sign + abs, cls };
 }
 


### PR DESCRIPTION
## Summary
- handle negative score difference color in `formatScoreDiff`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_688430e2dc70832f97e36887ce8a91b1