### PR TITLE
Fix net score color for negative values

### DIFF
--- a/miniapp/pages/myfriends/myfriends.wxss
+++ b/miniapp/pages/myfriends/myfriends.wxss
@@ -13,5 +13,6 @@ page{background:#f5f5f5;}
 .rate{font-size:24rpx;color:#666;margin-top:4rpx;}
 .score{font-size:24rpx;margin-top:4rpx;}
 .pos{color:green;}
+.neg{color:red;}
 .neutral{color:gray;}
 .empty{text-align:center;color:#999;padding:40rpx 0;}

--- a/miniapp/utils/format.js
+++ b/miniapp/utils/format.js
@@ -25,7 +25,7 @@ function formatScoreDiff(value) {
   }
   const abs = Math.abs(num).toFixed(3);
   const sign = num > 0 ? '+' : num < 0 ? '-' : '';
-  const cls = num === 0 ? 'neutral' : 'pos';
+  const cls = num > 0 ? 'pos' : num < 0 ? 'neg' : 'neutral';
   return { display: sign + abs, cls };
 }
 


### PR DESCRIPTION
## Summary
- add missing `.neg` CSS class in myfriends page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_688430e2dc70832f97e36887ce8a91b1