### PR TITLE
Fix doubles opponent count in friends stats

### DIFF
--- a/tennis/services/friends.py
+++ b/tennis/services/friends.py
@@ -104,7 +104,8 @@ def get_player_friends(user_id: str) -> list[dict[str, object]]:
             diff = after - before
         else:
             diff = 0.0
-        update(partner, win, m.format_weight, doubles=True, partner=True, score_diff=diff)
+        # partner interactions should not count towards doubles opponent stats
+        update(partner, win, m.format_weight, partner=True, score_diff=diff)
         for opp in opponents:
             update(opp, win, m.format_weight, doubles=True, score_diff=diff)
 


### PR DESCRIPTION
## Summary
- avoid counting doubles partners as opponents in aggregated friend statistics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testing')*

------
https://chatgpt.com/codex/tasks/task_e_68844deffe68832faa5979e4784ac51f